### PR TITLE
Remove "keep_pin" from the list of participants

### DIFF
--- a/helpers/content.js
+++ b/helpers/content.js
@@ -10,7 +10,7 @@ export function randomizeGMeetParticipants() {
   document
     .querySelectorAll(`div[role="list"] *[data-participant-id]`)
     .forEach((node) => {
-      if (!node.innerText.startsWith('Presentation')) {
+      if (!node.innerText.toLowerCase().includes('presentation')) {
         const text = node.innerText.split('\n')[0];
         const normalizedName = text.split('(You)');
         arr.push(normalizedName[0]);


### PR DESCRIPTION
Remove "keep_pin" from the list of participants. This occurs when the list is generated while someone is presenting.

Here is a simple before and after comparison:
![SCR-20230606-gac](https://github.com/LambyPants/google-meet-randomizer/assets/580672/07ec5a77-c40a-4bd0-a870-7b3419892855)
